### PR TITLE
feat: htcondor different condor jobID names

### DIFF
--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -472,6 +472,9 @@ pixi run driftless-star --max-iters 3 --cores 4
 | `--cores`     | `4`           | Cores passed to `snakemake --cores`.                 |
 | `--gpu-ids`   | the config's `gpu_ids` | Forwarded to every iteration's `snakemake --config` (see [Multi-GPU scheduling](#multi-gpu-scheduling)). |
 | `--jobs-per-gpu` | the config's `jobs_per_gpu` | Forwarded to every iteration's `snakemake --config`. |
+| `--profile`   | none, so iterations run locally | Snakemake profile directory forwarded to every iteration, e.g. `executors/htcondor/profiles/htcondor-gpu` to run on HTCondor. |
+| `--container-runtime` | the config's `container_runtime` | Tool that runs each stage's container, `docker` or `apptainer`. A cluster run needs `apptainer`, since the execute nodes have no Docker daemon. |
+| `--htcondor-jobdir` | the profile's `htcondor-jobdir` | Per-run directory for HTCondor's logs. Parallel controllers need distinct values (see [Where the logs go](../executors/htcondor/README.md#where-the-logs-go)). |
 
 > [!NOTE]
 > Each iteration is a full forward pass, so Docker must be running and all stage images must be available (the loop exercises `stage-1-vmec` through `stage-5-neopax`; the post-processing step reuses the Stage 5 image). The driver runs on the orchestration `pipeline` env, like Snakemake itself.

--- a/executors/htcondor/README.md
+++ b/executors/htcondor/README.md
@@ -83,7 +83,7 @@ The executor writes HTCondor's own log, stdout, and stderr under the profile's `
 - `jobs/snakemake-rules.log`: the unified HTCondor event log for every job
 - `jobs/<rule>/<rule>-<jobid>_<ClusterId>.out` / `.err`: per-job output
 
-Those paths are chosen by the plugin and cannot be redirected through `default-resources`.
+Those paths are chosen by the plugin and cannot be redirected through `default-resources`. The closed-loop driver's `--htcondor-jobdir` replaces `jobs/` for one run, and every iteration of that run is given the same directory. Two controllers sharing a checkout need distinct values: the event log is one file per directory, so otherwise both append to the same `jobs/snakemake-rules.log` and each reads the other's job events. Point it at a path on the submit host, which is where HTCondor writes the event log and where it returns each job's `.out` and `.err`.
 
 Each job's `.err` opens with `[job_wrapper]` diagnostics naming the Snakemake it resolved and that Snakemake's version, which is the first thing to read when jobs fail immediately.
 

--- a/src/ouroboros.py
+++ b/src/ouroboros.py
@@ -226,7 +226,7 @@ def run_forward_pass(
         Snakemake profile directory (e.g. ``executors/htcondor/profiles/htcondor-gpu``). Sends the
         iteration's jobs to a cluster executor instead of running them locally.
     htcondor_jobdir : str, optional
-        Per-run directory for HTCondor submit, error, output, and unified event-log files. Parallel
+        Per-run directory for HTCondor's error, output, and unified event-log files. Parallel
         controllers must not share this directory.
     """
     logger.info("Forward pass [%s]: snakemake %s --cores %d", output_dir, target, cores)

--- a/src/ouroboros.py
+++ b/src/ouroboros.py
@@ -209,6 +209,7 @@ def run_forward_pass(
     extra_configfiles: list[Path] | None = None,
     extra_config: list[str] | None = None,
     profile: str | None = None,
+    htcondor_jobdir: str | None = None,
 ) -> None:
     """
     Run one Snakemake forward pass for an iteration.
@@ -224,6 +225,9 @@ def run_forward_pass(
     profile : str, optional
         Snakemake profile directory (e.g. ``executors/htcondor/profiles/htcondor-gpu``). Sends the
         iteration's jobs to a cluster executor instead of running them locally.
+    htcondor_jobdir : str, optional
+        Per-run directory for HTCondor submit, error, output, and unified event-log files. Parallel
+        controllers must not share this directory.
     """
     logger.info("Forward pass [%s]: snakemake %s --cores %d", output_dir, target, cores)
     # Extra config files are appended under the single --configfile flag. A second flag
@@ -232,6 +236,8 @@ def run_forward_pass(
     cmd = ["snakemake", target, "--cores", str(cores)]
     if profile:
         cmd += ["--profile", profile]
+    if htcondor_jobdir:
+        cmd += ["--htcondor-jobdir", htcondor_jobdir]
     cmd += ["--configfile", str(config_path)]
     cmd += [str(p) for p in (extra_configfiles or [])]
     cmd += ["--config", f"input_dir={input_dir}", f"output_dir={output_dir}", *(extra_config or [])]
@@ -260,6 +266,8 @@ def main() -> None:
                         help="Override the config's container_runtime for every iteration. A cluster "
                              "profile normally needs 'apptainer', since the execute nodes have no "
                              "Docker daemon.")
+    parser.add_argument("--htcondor-jobdir", type=str, default=None,
+                        help="Per-run HTCondor log directory. Parallel controllers must use distinct values.")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
@@ -337,7 +345,7 @@ def main() -> None:
         run_forward_pass(target=iter_p["s5_signal"], input_dir=iter_in, output_dir=iter_out,
                          cores=args.cores, config_path=config_path, repo_root=repo_root,
                          extra_configfiles=extra_configfiles, extra_config=config_overrides or None,
-                         profile=args.profile)
+                         profile=args.profile, htcondor_jobdir=args.htcondor_jobdir)
 
         prev_p = iter_p  # post-processing wrote both feedback artifacts; they seed iteration n+1
         signal = json.loads(_abs(repo_root, iter_p["s5_signal"]).read_text())

--- a/tests/orchestration/test_ouroboros_cluster.py
+++ b/tests/orchestration/test_ouroboros_cluster.py
@@ -2,12 +2,14 @@
 
 ``--profile`` sends the loop's forward passes to a cluster executor instead of the local machine, and
 ``--container-runtime`` picks the tool that runs each stage's container, since an execute node has no
-Docker daemon and an HTCondor run needs ``apptainer``. Neither flag is useful without the other.
+Docker daemon and an HTCondor run needs ``apptainer``. Neither of those two is useful without the
+other. ``--htcondor-jobdir`` then gives one run its own directory for HTCondor's logs, which parallel
+controllers need so they do not both append to the same unified event log.
 
 What makes them worth testing is that they fail quietly. A ``--profile`` the driver forgets to emit
 raises no error at all -- the loop simply keeps running locally, and nobody notices until they wonder
 why the cluster queue is empty. So these tests assemble the command line the driver would run, without
-running it, and check that both flags are present, correctly positioned, and repeated on every
+running it, and check that each flag is present, correctly positioned, and repeated on every
 iteration, and that an unknown runtime is rejected on the submit host rather than inside the first
 cluster job.
 
@@ -52,16 +54,20 @@ def test_profile_survives_an_extra_configfile(monkeypatch: pytest.MonkeyPatch) -
     assert cmd[6:9] == ["--configfile", "cfg.yaml", "loop_overrides.yaml"]
 
 
-def test_htcondor_jobdir_is_forwarded_to_snakemake(monkeypatch: pytest.MonkeyPatch) -> None:
-    cmd = _captured_argv(monkeypatch, profile=PROFILE, htcondor_jobdir="/staging/runs/id1/htcondor")
+def test_htcondor_jobdir_survives_an_extra_configfile(monkeypatch: pytest.MonkeyPatch) -> None:
+    cmd = _captured_argv(monkeypatch, profile=PROFILE, htcondor_jobdir="/staging/runs/id1/htcondor",
+                         extra_configfiles=[Path("loop_overrides.yaml")])
 
-    assert cmd[cmd.index("--htcondor-jobdir") + 1] == "/staging/runs/id1/htcondor"
+    assert cmd[:8] == ["snakemake", "out/converge_status.json", "--cores", "4", "--profile", PROFILE,
+                       "--htcondor-jobdir", "/staging/runs/id1/htcondor"]
+    assert cmd[8:11] == ["--configfile", "cfg.yaml", "loop_overrides.yaml"]
 
 
-# Both flags describe where the whole invocation runs, not one pass of it, so every iteration has to
-# receive them. An iteration that lost either would quietly fall back to a local docker run partway
-# through the loop.
-def test_both_flags_reach_every_iteration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+# Each flag describes where the whole invocation runs, not one pass of it, so every iteration has to
+# receive all three. An iteration that lost --profile or --container-runtime would quietly fall back to
+# a local docker run partway through the loop; one that lost --htcondor-jobdir would write that
+# iteration's HTCondor logs to the shared directory the profile names.
+def test_cluster_flags_reach_every_iteration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = _write_config(tmp_path)
     monkeypatch.setattr(ouroboros, "_seed_iteration_inputs", lambda **kw: None)
 

--- a/tests/orchestration/test_ouroboros_cluster.py
+++ b/tests/orchestration/test_ouroboros_cluster.py
@@ -52,6 +52,12 @@ def test_profile_survives_an_extra_configfile(monkeypatch: pytest.MonkeyPatch) -
     assert cmd[6:9] == ["--configfile", "cfg.yaml", "loop_overrides.yaml"]
 
 
+def test_htcondor_jobdir_is_forwarded_to_snakemake(monkeypatch: pytest.MonkeyPatch) -> None:
+    cmd = _captured_argv(monkeypatch, profile=PROFILE, htcondor_jobdir="/staging/runs/id1/htcondor")
+
+    assert cmd[cmd.index("--htcondor-jobdir") + 1] == "/staging/runs/id1/htcondor"
+
+
 # Both flags describe where the whole invocation runs, not one pass of it, so every iteration has to
 # receive them. An iteration that lost either would quietly fall back to a local docker run partway
 # through the loop.
@@ -61,18 +67,19 @@ def test_both_flags_reach_every_iteration(monkeypatch: pytest.MonkeyPatch, tmp_p
 
     forwarded: list[tuple] = []
 
-    def fake_run(*, target, extra_config=None, profile=None, **kw):
-        forwarded.append((profile, extra_config))
+    def fake_run(*, target, extra_config=None, profile=None, htcondor_jobdir=None, **kw):
+        forwarded.append((profile, extra_config, htcondor_jobdir))
         signal = Path(target)
         signal.parent.mkdir(parents=True, exist_ok=True)
         signal.write_text(json.dumps({"status": "continue"}))  # neither halt nor converged -> keep looping
 
     monkeypatch.setattr(ouroboros, "run_forward_pass", fake_run)
     monkeypatch.setattr("sys.argv", ["ouroboros", "--config", str(config_path), "--max-iters", "2",
-                                     "--profile", PROFILE, "--container-runtime", "apptainer"])
+                                     "--profile", PROFILE, "--container-runtime", "apptainer",
+                                     "--htcondor-jobdir", "/staging/runs/id1/htcondor"])
     ouroboros.main()
 
-    assert forwarded == [(PROFILE, ["container_runtime=apptainer"])] * 2
+    assert forwarded == [(PROFILE, ["container_runtime=apptainer"], "/staging/runs/id1/htcondor")] * 2
 
 
 # The choices list makes a typo fail at parse time on the submit host, rather than as an unclear


### PR DESCRIPTION
Resolves #148 .

The code basically enforces each jobID to align with config names.