### PR TITLE
feat: Add selectable pressure convergence methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A *run* is a folder under `inputs/` holding its run config (`config.yaml`) and e
 pixi run driftless-star --config inputs/quick_run/config.yaml --max-iters 3 --cores 4
 ```
 
-Each iteration is a full pipeline run under its own `outputs/<run>/loop/iter_N/` tree (`outputs/` is gitignored), and the driver stops early once the pressure profile settles within the config's `convergence.pressure_rel_tol`. Stages listed under `loop.rerun` as `false` are frozen, so iterations after the first reuse their iteration 1 artifacts. See [docs/mvp-pipeline.md](docs/mvp-pipeline.md#closing-the-loop).
+Each iteration is a full pipeline run under its own `outputs/<run>/loop/iter_N/` tree (`outputs/` is gitignored), and the driver stops early once the pressure profile settles under the config's `convergence.method` (`rms` or `pointwise`) and `convergence.pressure_rel_tol`. Stages listed under `loop.rerun` as `false` are frozen, so iterations after the first reuse their iteration 1 artifacts. See [docs/mvp-pipeline.md](docs/mvp-pipeline.md#closing-the-loop).
 
 ### Run a single forward pass
 

--- a/Snakefile
+++ b/Snakefile
@@ -158,7 +158,8 @@ STAGE4_CFG = config["stage4"]["gkx"]
 # Resolved here rather than beside its rule so a misspelled convention is caught even when the run freezes Stage 4.
 RADIUS_RELABEL_CONVENTION = stage4_helper.resolve_radius_relabel(config)
 
-# Stage 5 post-processing convergence threshold (see the `convergence` block in inputs/<run>/config.yaml).
+# Stage 5 post-processing convergence criterion (see the `convergence` block in inputs/<run>/config.yaml).
+PRESSURE_CONVERGENCE_METHOD = stage5_helper.resolve_pressure_convergence_method(config)
 PRESSURE_REL_TOL = config.get("convergence", {}).get("pressure_rel_tol", 1.0e-2)
 
 # Write a path-resolved copy of the NEOPAX template under outputs/ and run that (template untouched).
@@ -386,5 +387,6 @@ rule stage5_post_processing:
         '{input.transport} {input.common_config} --output-toml {output.profiles_feedback} && '
         'python stages/stage5-post-processing/stage5_post_processing.py '
         '--transport {input.transport} --common-config {input.common_config} '
-        f'--signal {{output.signal}} --pressure-rel-tol {PRESSURE_REL_TOL}"'
+        f'--signal {{output.signal}} --pressure-rel-tol {PRESSURE_REL_TOL} '
+        f'--pressure-convergence-method {PRESSURE_CONVERGENCE_METHOD}"'
         " 2>&1 | tee {log}"

--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -570,24 +570,32 @@ outputs/<run>/loop/iter_N/
 
 ### Convergence
 
-Convergence is decided by `pressure_converged()` in `stage5_post_processing.py`. A pass is converged when this pass's `transport_solution.h5` shows the total pressure profile `P(rho)` has reached steady state, i.e. the root-mean-square (over rho) of the pointwise relative change between its initial and final time slices falls below the configured tolerance:
+Convergence is decided by the configured pressure method in `stage5_post_processing.py`. Both methods compare the total pressure profile `P(rho)` in this pass's `transport_solution.h5` between its initial and final time slices. `resolve_pressure_convergence()` selects one of:
+
+- `rms`, implemented by `rms_pressure_converged()`: the root-mean-square over rho of the pointwise relative change must satisfy
 
 ```
 sqrt( mean_rho[ ((P_final - P_initial) / P_initial)^2 ] ) < pressure_rel_tol
 ```
 
-Normalising by the number of rho points (rather than a bare L2 norm) keeps `pressure_rel_tol` independent of the profile's radial resolution.
+- `pointwise` (the default), implemented by `pointwise_pressure_converged()`: the maximum absolute pointwise relative change must satisfy
 
-`pressure_rel_tol` is set in the top-level `convergence` block of the run config (defaulting to `1.0e-2`). Stage 5 post-processing (`build_signal()`) writes `converge_status.json` as `{"status": <string>}`, and `ouroboros` runs another pass only on `"continue"`. The four statuses, in the order `build_signal()` tests them:
+```
+max_rho | (P_final - P_initial) / P_initial | < pressure_rel_tol
+```
+
+The RMS method allows a change confined to a few radii to be averaged below the tolerance, while the pointwise method requires every radius to settle within it. Both measures stay independent of the profile's radial resolution.
+
+`method` and `pressure_rel_tol` are set in the top-level `convergence` block of the run config, defaulting to `pointwise` and `1.0e-2` when omitted. Stage 5 post-processing (`build_signal()`) writes `converge_status.json` as `{"status": <string>}`, and `ouroboros` runs another pass only on `"continue"`. The four statuses, in the order `build_signal()` tests them:
 
 | Status | Meaning | Set when |
 | --- | --- | --- |
 | `halted` | the run cannot continue | the total pressure is non-positive at any rho on the initial or final time slice, i.e. the equilibrium was not sustained. Restart from different initial conditions rather than feed a collapsed profile forward. |
-| `converged` | the profile has settled | the relative RMS change above is below `pressure_rel_tol`. Reported ahead of `horizon`, since a pass that both settled and ran out of time is better described as settled. |
+| `converged` | the profile has settled | the selected pressure-change measure is below `pressure_rel_tol`. Reported ahead of `horizon`, since a pass that both settled and ran out of time is better described as settled. |
 | `horizon` | no transport time is left | the solution's `final_time` has reached `[transport_solver].t_final`. Because each pass resumes where the last one stopped, `t_final` is an absolute end time and not a per-pass window length, so there is nothing further to advance into. Raise `t_final` to keep evolving. |
 | `continue` | none of the above | the loop runs another pass, up to `--max-iters`. |
 
-If the transport solution has fewer than two distinct time slices, convergence cannot be assessed and the pass is not converged, which is neither a halt nor an error. A `return_converged_false()` placeholder is kept under an "Alternative Convergence Criteria" comment so a different criterion can be swapped in.
+If the transport solution has fewer than two distinct time slices, convergence cannot be assessed and the pass is not converged, which is neither a halt nor an error.
 
 > [!NOTE]
 > To render the file-flow graph *including* this post-processing step, target the signal file; see the [README](../README.md#visualize-the-pipeline-graph). Omitting the target graphs the plain forward pass (stops at Stage 5).

--- a/inputs/quick_run/config.yaml
+++ b/inputs/quick_run/config.yaml
@@ -29,11 +29,11 @@ filenames:
   s5_output: transport_solution.h5
   s5_signal: converge_status.json
 
-# Convergence criteria
-# Converged when the relative RMS change of the total pressure profile between
-# the initial and final transport time slices is below this tolerance:
-#   ||P_final - P_initial|| / ||P_initial|| < pressure_rel_tol
+# Pressure convergence criterion. Options:
+#   rms:       sqrt(mean(((P_final - P_initial) / P_initial)^2))
+#   pointwise: max(abs((P_final - P_initial) / P_initial))
 convergence:
+  method: pointwise
   pressure_rel_tol: 1.0e-2
 
 # Per-stage rerun flags for the ouroboros closed-loop driver, where a stage set to false

--- a/src/stage5_helper.py
+++ b/src/stage5_helper.py
@@ -13,6 +13,41 @@ from pathlib import Path
 
 from .utils import apply_assignments
 
+PRESSURE_CONVERGENCE_METHODS = ("rms", "pointwise")
+
+
+def resolve_pressure_convergence_method(config: dict) -> str:
+    """Return the configured pressure convergence method, defaulting to pointwise.
+
+    Parameters
+    ----------
+    config : dict
+        Parsed run config. ``convergence.method`` may be ``"rms"`` or
+        ``"pointwise"``.
+
+    Returns
+    -------
+    str
+        The validated convergence method.
+
+    Raises
+    ------
+    ValueError
+        If the convergence block is not a mapping or its method is unsupported.
+    """
+    convergence = config.get("convergence", {})
+    if not isinstance(convergence, dict):
+        raise ValueError(
+            f"config['convergence'] must be a mapping, got {convergence!r}."
+        )
+    method = convergence.get("method", "pointwise")
+    if not isinstance(method, str) or method not in PRESSURE_CONVERGENCE_METHODS:
+        choices = ", ".join(repr(choice) for choice in PRESSURE_CONVERGENCE_METHODS)
+        raise ValueError(
+            f"config['convergence']['method'] must be one of {choices}, got {method!r}."
+        )
+    return method
+
 
 def read_rho_edge(s5_config_template: str) -> float:
     """Return ``[geometry].rho_edge`` from the NEOPAX template, or NEOPAX's default of 1.0.

--- a/stages/stage5-post-processing/stage5_post_processing.py
+++ b/stages/stage5-post-processing/stage5_post_processing.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 import h5py
@@ -31,13 +32,13 @@ except ModuleNotFoundError:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-def pressure_converged(transport: Path, *, rel_tol: float) -> bool:
-    """Return whether Stage 5's transport evolution has reached steady state.
+def _pressure_converged(transport: Path, *, rel_tol: float, method: str) -> bool:
+    """Return whether Stage 5's transport evolution meets ``method``'s criterion.
 
     Compares the total pressure profile `P(rho)` at the final time slice of `transport`
     against the initial time slice. A small final-vs-initial change means the transport
     evolution barely moved the input profile, so the boundary fed back to Stage 1 is
-    self-consistent. 
+    self-consistent.
 
     Parameters
     ----------
@@ -45,12 +46,20 @@ def pressure_converged(transport: Path, *, rel_tol: float) -> bool:
         This pass's ``transport_solution.h5`` (species-resolved ``pressure_faces`` or
         ``temperature_faces`` and ``density_faces``, plus ``rho_face``).
     rel_tol : float
-        Relative RMS tolerance; convergence requires the relative change below it.
+        Relative tolerance; convergence requires the selected measure to be below it.
+    method : str
+        Relative-change measure: ``"rms"`` or ``"pointwise"``.
 
     Returns
     -------
     bool
-        ``True`` if the relative RMS change is below ``rel_tol``, else ``False``.
+        ``True`` if the selected relative-change measure is below ``rel_tol``, else
+        ``False``.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not ``"rms"`` or ``"pointwise"``.
 
     Notes
     -----
@@ -59,6 +68,11 @@ def pressure_converged(transport: Path, *, rel_tol: float) -> bool:
     be assessed; this returns ``False`` with a warning so the loop never stops on a
     non-evolving profile.
     """
+    if method not in {"rms", "pointwise"}:
+        raise ValueError(
+            f"Unsupported pressure convergence method {method!r}; expected one of: rms, pointwise"
+        )
+
     _, p_initial, idx_initial = _load_total_pressure(transport, time_index=0, final_time=False)
     _, p_final, idx_final = _load_total_pressure(transport, time_index=-1, final_time=True)
 
@@ -70,19 +84,44 @@ def pressure_converged(transport: Path, *, rel_tol: float) -> bool:
         )
         return False
 
-    # Root-mean-square of the pointwise relative change. Normalising by the number of
-    # rho points keeps rel_tol grid-resolution independent, so it
-    # reads as a true relative tolerance regardless of the profile's radial resolution.
     rel = (p_final - p_initial) / p_initial
-    rel_change = float(np.sqrt(np.mean(rel**2)))
-    logger.info("pressure relative RMS change = %.3e (rel_tol = %.3e)", rel_change, rel_tol)
+    if method == "rms":
+        # Normalising by the number of rho points keeps the RMS grid-resolution independent.
+        rel_change = float(np.sqrt(np.mean(rel**2)))
+        measure = "relative RMS"
+    else:
+        # Every rho point must settle within rel_tol; a local change cannot be averaged away.
+        rel_change = float(np.max(np.abs(rel)))
+        measure = "maximum pointwise relative"
+
+    logger.info("pressure %s change = %.3e (rel_tol = %.3e)", measure, rel_change, rel_tol)
     return rel_change < rel_tol
 
 
-# Alternative convergence criterion
-def return_converged_false(transport: Path) -> bool:
-    """Always report not converged (placeholder criterion, kept as an alternative)."""
-    return False
+def rms_pressure_converged(transport: Path, *, rel_tol: float) -> bool:
+    """Return whether the relative RMS pressure change is below ``rel_tol``."""
+    return _pressure_converged(transport, rel_tol=rel_tol, method="rms")
+
+
+def pointwise_pressure_converged(transport: Path, *, rel_tol: float) -> bool:
+    """Return whether every point's relative pressure change is below ``rel_tol``."""
+    return _pressure_converged(transport, rel_tol=rel_tol, method="pointwise")
+
+
+_PRESSURE_CONVERGENCE_METHODS: dict[str, Callable[..., bool]] = {
+    "rms": rms_pressure_converged,
+    "pointwise": pointwise_pressure_converged,
+}
+
+
+def resolve_pressure_convergence(method: str) -> Callable[..., bool]:
+    """Return the pressure convergence function registered for ``method``."""
+    try:
+        return _PRESSURE_CONVERGENCE_METHODS[method]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported pressure convergence method {method!r}; expected one of: rms, pointwise"
+        ) from None
 
 
 def transport_horizon_reached(transport: Path, common_config: Path) -> bool:
@@ -129,7 +168,13 @@ def transport_horizon_reached(transport: Path, common_config: Path) -> bool:
     return final_time >= t_final
 
 
-def build_signal(transport: Path, *, rel_tol: float, common_config: Path) -> dict[str, str]:
+def build_signal(
+    transport: Path,
+    *,
+    rel_tol: float,
+    common_config: Path,
+    convergence_method: str = "pointwise",
+) -> dict[str, str]:
     """Build the closed-loop status signal for the driver.
 
     The status is ``continue``, ``converged``, ``horizon`` or ``halted``. The driver runs another
@@ -140,15 +185,19 @@ def build_signal(transport: Path, *, rel_tol: float, common_config: Path) -> dic
     transport : Path
         This pass's ``transport_solution.h5``.
     rel_tol : float
-        Relative RMS tolerance forwarded to the convergence criterion.
+        Relative tolerance forwarded to the selected convergence criterion.
     common_config : Path
         The ``common_input.toml`` used for this pass. It supplies the configured horizon.
+    convergence_method : str
+        Pressure convergence method, ``"rms"`` or ``"pointwise"`` (the default).
 
     Returns
     -------
     dict
         Mapping with one ``status`` string.
     """
+    pressure_converged = resolve_pressure_convergence(convergence_method)
+
     for label, time_index, final_time in (("initial", 0, False), ("final", -1, True)):
         _, pressure, _ = _load_total_pressure(transport, time_index=time_index, final_time=final_time)
         if np.any(pressure <= 0.0):
@@ -181,12 +230,23 @@ def main() -> None:
     parser.add_argument("--signal", type=Path, required=True,
                         help="Output path for the status JSON the driver reads.")
     parser.add_argument("--pressure-rel-tol", type=float, required=True,
-                        help="Relative RMS tolerance on the final-vs-initial total pressure profile.")
+                        help="Relative tolerance on the final-vs-initial total pressure profile.")
+    parser.add_argument(
+        "--pressure-convergence-method",
+        choices=_PRESSURE_CONVERGENCE_METHODS,
+        default="pointwise",
+        help="Pressure convergence method: rms or pointwise (default).",
+    )
     args = parser.parse_args()
     if args.pressure_rel_tol <= 0.0:
         parser.error(f"--pressure-rel-tol must be positive, got {args.pressure_rel_tol}.")
 
-    status = build_signal(args.transport, rel_tol=args.pressure_rel_tol, common_config=args.common_config)
+    status = build_signal(
+        args.transport,
+        rel_tol=args.pressure_rel_tol,
+        common_config=args.common_config,
+        convergence_method=args.pressure_convergence_method,
+    )
     args.signal.parent.mkdir(parents=True, exist_ok=True)
     args.signal.write_text(json.dumps(status) + "\n")
     print(f"# converge_status: {status}")

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -70,6 +70,13 @@ def _dry_run(
     )
 
 
+def _write_convergence_override(tmp_path: Path, method: str) -> str:
+    """Write a layered run config that changes only the convergence method."""
+    path = tmp_path / f"convergence-{method}.yaml"
+    path.write_text(yaml.safe_dump({"convergence": {"method": method}}))
+    return str(path)
+
+
 # This runs the default forward pass and asserts it plans successfully (exit code 0), that every stage rule visible
 # before the checkpoints run is scheduled (including both deferred collect gathers), and that the post-processing rule
 # is NOT scheduled, because the default target is a pure forward pass with no loop-closing step. This catches Snakefile
@@ -100,6 +107,40 @@ def test_s5_signal_target_schedules_post_processing(tmp_path: Path) -> None:
     # Requesting the convergence signal pulls in the loop-closing rule and formats its
     # shell string, which rule all (a pure forward pass) never reaches.
     assert "stage5_post_processing" in output, output
+
+
+def test_convergence_method_reaches_the_post_processing_command(tmp_path: Path) -> None:
+    config = yaml.safe_load((REPO_ROOT / "inputs/quick_run/config.yaml").read_text())
+    s5_signal = resolve_pipeline_paths(config, output_dir=f"{tmp_path}/out")["s5_signal"]
+
+    baseline = _dry_run(tmp_path, targets=[s5_signal], config_overrides=[], printshellcmds=True)
+    baseline_output = baseline.stdout + baseline.stderr
+    assert baseline.returncode == 0, baseline_output
+    assert "--pressure-convergence-method pointwise" in baseline_output, baseline_output
+
+    rms = _dry_run(
+        tmp_path,
+        targets=[s5_signal],
+        config_overrides=[],
+        extra_configfiles=[_write_convergence_override(tmp_path, "rms")],
+        printshellcmds=True,
+    )
+    rms_output = rms.stdout + rms.stderr
+    assert rms.returncode == 0, rms_output
+    assert "--pressure-convergence-method rms" in rms_output, rms_output
+
+
+def test_unknown_convergence_method_fails_at_parse_time(tmp_path: Path) -> None:
+    result = _dry_run(
+        tmp_path,
+        targets=[],
+        config_overrides=[],
+        extra_configfiles=[_write_convergence_override(tmp_path, "maximum")],
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "config['convergence']['method']" in output, output
+    assert "'rms', 'pointwise'" in output, output
 
 
 # From iteration 2 the loop driver appends its loop_overrides.yaml after the base config file, switching both stage

--- a/tests/orchestration/test_stage5_helper.py
+++ b/tests/orchestration/test_stage5_helper.py
@@ -15,7 +15,11 @@ from pathlib import Path
 
 import pytest
 
-from src.stage5_helper import prepare_neopax_config, read_rho_edge
+from src.stage5_helper import (
+    prepare_neopax_config,
+    read_rho_edge,
+    resolve_pressure_convergence_method,
+)
 
 _TEMPLATE = (
     'vmec_file = "PLACEHOLDER"\n'
@@ -24,6 +28,34 @@ _TEMPLATE = (
     'turbulence_file = "PLACEHOLDER"\n'
     'transport_output_dir = "PLACEHOLDER"\n'
 )
+
+
+# --- convergence method ---
+
+
+@pytest.mark.parametrize(
+    "config",
+    [{}, {"convergence": {}}, {"convergence": {"pressure_rel_tol": 1.0e-2}}],
+)
+def test_pressure_convergence_method_defaults_to_pointwise(config: dict) -> None:
+    assert resolve_pressure_convergence_method(config) == "pointwise"
+
+
+@pytest.mark.parametrize("method", ["rms", "pointwise"])
+def test_pressure_convergence_method_accepts_supported_values(method: str) -> None:
+    assert resolve_pressure_convergence_method({"convergence": {"method": method}}) == method
+
+
+@pytest.mark.parametrize("method", ["RMS", "maximum", True, None, 1])
+def test_pressure_convergence_method_rejects_unsupported_values(method: object) -> None:
+    with pytest.raises(ValueError, match=r"config\['convergence'\]\['method'\]"):
+        resolve_pressure_convergence_method({"convergence": {"method": method}})
+
+
+@pytest.mark.parametrize("convergence", [None, "rms", ["rms"]])
+def test_pressure_convergence_method_requires_a_mapping(convergence: object) -> None:
+    with pytest.raises(ValueError, match=r"config\['convergence'\] must be a mapping"):
+        resolve_pressure_convergence_method({"convergence": convergence})
 
 
 def _prepare(tmp_path: Path) -> tuple[Path, Path]:

--- a/tests/stage5-transport/test_convergence_signal.py
+++ b/tests/stage5-transport/test_convergence_signal.py
@@ -1,6 +1,6 @@
 """Tests for the Stage 5 post-processing convergence signal.
 
-These reuse the real ``pressure_converged`` and ``build_signal`` from
+These reuse the real pressure-convergence functions and ``build_signal`` from
 ``stage5_post_processing.py``, loaded by path. That script imports its sibling
 ``fit_vmec_pressure_from_transport_h5`` at module top, so loading it also exercises
 the sibling-import support in ``load_stage_module``.
@@ -8,6 +8,8 @@ the sibling-import support in ``load_stage_module``.
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -36,26 +38,71 @@ def _write(path: Path, pressure: np.ndarray, pressure_face: np.ndarray, n_rho: i
     )
 
 
-# `pressure_converged` decides whether the loop has settled by comparing the last two time slices of the pressure
-# profile. A static (single-slice) profile has no change to measure, so convergence cannot be confirmed: this writes
-# such a file and asserts the function returns False.
-def test_pressure_converged_false_for_static_profile(tmp_path: Path) -> None:
+# Both criteria compare the first and final pressure slices. A static profile has no
+# change to measure, so neither criterion may report convergence.
+@pytest.mark.parametrize(
+    "criterion",
+    [post.rms_pressure_converged, post.pointwise_pressure_converged],
+    ids=["rms", "pointwise"],
+)
+def test_pressure_converged_false_for_static_profile(tmp_path: Path, criterion) -> None:
     f = _write(tmp_path / "static.h5", _static(2.0), _static(2.0, n_rho=6))
-    assert not post.pressure_converged(f, rel_tol=1e-2)
+    assert not criterion(f, rel_tol=1e-2)
 
 
-def test_pressure_converged_true_for_small_change(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "criterion",
+    [post.rms_pressure_converged, post.pointwise_pressure_converged],
+    ids=["rms", "pointwise"],
+)
+def test_pressure_converged_true_for_small_change(tmp_path: Path, criterion) -> None:
     slice0 = _static(2.0, n_rho=6)
     pressure_3d = np.stack([slice0, slice0 * 1.0001])  # 0.01% change between slices
     f = _write(tmp_path / "small.h5", np.stack([_static(2.0)] * 2), pressure_3d)
-    assert post.pressure_converged(f, rel_tol=1e-2)
+    assert criterion(f, rel_tol=1e-2)
 
 
-def test_pressure_converged_false_for_large_change(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "criterion",
+    [post.rms_pressure_converged, post.pointwise_pressure_converged],
+    ids=["rms", "pointwise"],
+)
+def test_pressure_converged_false_for_large_change(tmp_path: Path, criterion) -> None:
     slice0 = _static(2.0, n_rho=6)
     pressure_3d = np.stack([slice0, slice0 * 2.0])  # 100% change between slices
     f = _write(tmp_path / "large.h5", np.stack([_static(2.0)] * 2), pressure_3d)
-    assert not post.pressure_converged(f, rel_tol=1e-2)
+    assert not criterion(f, rel_tol=1e-2)
+
+
+# A 2% change at one of six faces has an RMS of 0.02/sqrt(6), below the 1%
+# tolerance, but its maximum pointwise change remains 2%.
+def test_pressure_convergence_methods_distinguish_a_single_point_change(tmp_path: Path) -> None:
+    slice0 = _static(2.0, n_rho=6)
+    slice1 = slice0.copy()
+    slice1[:, 3] *= 1.02
+    f = _write(tmp_path / "spike.h5", np.stack([_static(2.0)] * 2), np.stack([slice0, slice1]))
+
+    assert post.rms_pressure_converged(f, rel_tol=1e-2)
+    assert not post.pointwise_pressure_converged(f, rel_tol=1e-2)
+
+
+@pytest.mark.parametrize(
+    ("method", "criterion"),
+    [
+        ("rms", post.rms_pressure_converged),
+        ("pointwise", post.pointwise_pressure_converged),
+    ],
+)
+def test_resolve_pressure_convergence_returns_registered_function(method: str, criterion) -> None:
+    assert post.resolve_pressure_convergence(method) is criterion
+
+
+def test_resolve_pressure_convergence_rejects_unknown_method() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"Unsupported pressure convergence method 'RMS'; expected one of: rms, pointwise",
+    ):
+        post.resolve_pressure_convergence("RMS")
 
 
 # Transport horizon
@@ -126,6 +173,56 @@ def test_build_signal_reports_convergence_ahead_of_the_horizon(tmp_path: Path) -
     pressure_3d = np.stack([slice0, slice0 * 1.0001])
     f = _with_clock(_write(tmp_path / "ok.h5", np.stack([_static(2.0)] * 2), pressure_3d), 2.0)
     assert post.build_signal(f, rel_tol=1e-2, common_config=_clock_template(tmp_path)) == {"status": "converged"}
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_status"),
+    [("rms", "converged"), ("pointwise", "continue")],
+)
+def test_build_signal_uses_the_selected_pressure_convergence_method(
+    tmp_path: Path, method: str, expected_status: str
+) -> None:
+    slice0 = _static(2.0, n_rho=6)
+    slice1 = slice0.copy()
+    slice1[:, 3] *= 1.02
+    f = _with_clock(
+        _write(tmp_path / f"spike-{method}.h5", np.stack([_static(2.0)] * 2), np.stack([slice0, slice1])),
+        1.0,
+    )
+    assert post.build_signal(
+        f,
+        rel_tol=1e-2,
+        common_config=_clock_template(tmp_path),
+        convergence_method=method,
+    ) == {"status": expected_status}
+
+
+def test_main_accepts_the_pointwise_method_from_the_cli(tmp_path: Path, monkeypatch) -> None:
+    slice0 = _static(2.0, n_rho=6)
+    slice1 = slice0.copy()
+    slice1[:, 3] *= 1.02
+    transport = _with_clock(
+        _write(tmp_path / "cli-spike.h5", np.stack([_static(2.0)] * 2), np.stack([slice0, slice1])),
+        1.0,
+    )
+    common_config = _clock_template(tmp_path)
+    signal = tmp_path / "signal.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "stage5_post_processing.py",
+            "--transport", str(transport),
+            "--common-config", str(common_config),
+            "--signal", str(signal),
+            "--pressure-rel-tol", "0.01",
+            "--pressure-convergence-method", "pointwise",
+        ],
+    )
+
+    post.main()
+
+    assert json.loads(signal.read_text()) == {"status": "continue"}
 
 
 # This profile is not settled and has no transport time left. Another pass would repeat the same


### PR DESCRIPTION
Resolves #151 

## Summary

* `stages/stage5-post-processing/stage5_post_processing.py` adds shared pressure convergence logic. `rms_pressure_converged()` and `pointwise_pressure_converged()` select the reduction method. `resolve_pressure_convergence()` selects the configured function. Unknown methods raise an error instead of selecting a fallback.
* `src/stage5_helper.py`, `Snakefile`, and `inputs/quick_run/config.yaml` add `convergence.method`. Pointwise is the default. Config validation accepts only `rms` and `pointwise`. The Stage 5 command receives the selected method through `--pressure-convergence-method`.
* `README.md` and `docs/mvp-pipeline.md` state both formulas. They explain how RMS can average a local change and how pointwise checks every radial point.
* `tests/stage5-transport/test_convergence_signal.py` collects 22 cases. `tests/orchestration/test_stage5_helper.py` collects 24 cases. `tests/e2e/test_dry_run_dag.py` collects 15 cases. The new cases cover both methods, the pointwise default, config validation, command wiring, and a local pressure change that distinguishes the two methods.

## Design Decisions

### Pointwise is the default pressure criterion

Pointwise convergence requires every radial point to meet `pressure_rel_tol`. RMS can average a local change below the same tolerance. The config keeps RMS as an explicit choice for studies that need the averaging criterion.

### Configuration fails before jobs start

`src/stage5_helper.py` validates `convergence.method` when Snakemake parses the config. Argparse validates direct script calls. These checks reject unknown values before Stage 5 can apply the wrong criterion.

### Named functions share one calculation path

`_pressure_converged()` loads the first and final pressure profiles. It rejects unsupported internal methods and returns `False` for a static profile. The two public functions select only the reduction method. This structure keeps tolerance comparison and logging consistent.

---

**Tested:**

* [x] `pixi run -e test test` passed 680 tests and 4 doctests. It skipped 7 tests.
* [x] The same task at merge base `501e504` passed 655 tests and 4 doctests. It skipped 7 tests.
* [x] The three changed test files collect 61 cases.
* [x] `git diff --check main...HEAD` passed.
