### PR TITLE
Bump NEOPAX pin to 7a05af8

### DIFF
--- a/stages/pixi.lock
+++ b/stages/pixi.lock
@@ -4101,7 +4101,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=8aeb02c0d77b2febc5a276aad5bbbae600d202eb#8aeb02c0d77b2febc5a276aad5bbbae600d202eb
+      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc#7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/65/ffc0b4522b5e22bb594299e0adc1538f81f29ae79e4ba7d360eca18965a3/orthax-0.2.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -4301,7 +4301,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=8aeb02c0d77b2febc5a276aad5bbbae600d202eb#8aeb02c0d77b2febc5a276aad5bbbae600d202eb
+      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc#7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/66/65/ffc0b4522b5e22bb594299e0adc1538f81f29ae79e4ba7d360eca18965a3/orthax-0.2.9-py3-none-any.whl
@@ -4444,7 +4444,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=8aeb02c0d77b2febc5a276aad5bbbae600d202eb#8aeb02c0d77b2febc5a276aad5bbbae600d202eb
+      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc#7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/66/65/ffc0b4522b5e22bb594299e0adc1538f81f29ae79e4ba7d360eca18965a3/orthax-0.2.9-py3-none-any.whl
@@ -4680,7 +4680,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=8aeb02c0d77b2febc5a276aad5bbbae600d202eb#8aeb02c0d77b2febc5a276aad5bbbae600d202eb
+      - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc#7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/65/ffc0b4522b5e22bb594299e0adc1538f81f29ae79e4ba7d360eca18965a3/orthax-0.2.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -22117,9 +22117,9 @@ packages:
   - twine ; extra == 'dev'
   - pillow ; extra == 'assets'
   requires_python: '>=3.10'
-- pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=8aeb02c0d77b2febc5a276aad5bbbae600d202eb#8aeb02c0d77b2febc5a276aad5bbbae600d202eb
+- pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc#7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc
   name: neopax
-  version: 0.1.dev1546+g8aeb02c0d.d20260814
+  version: 0.1.dev1875+g7a05af8be.d20260908
   requires_dist:
   - jax
   - jaxlib

--- a/stages/pixi.toml
+++ b/stages/pixi.toml
@@ -90,7 +90,7 @@ netcdf4 = ">=1.7.4,<2"
 
 [feature.neopax.pypi-dependencies]
 orthax = ">=0.2.8, <0.3"
-neopax = { git = "https://github.com/uwplasma/NEOPAX.git", rev = "8aeb02c0d77b2febc5a276aad5bbbae600d202eb" }
+neopax = { git = "https://github.com/uwplasma/NEOPAX.git", rev = "7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc" }
 
 [feature.neopax.tasks.stage-5-neopax]
 cwd = "../inputs/quick_run"


### PR DESCRIPTION
The NEOPAX pin moves from `uwplasma/NEOPAX@8aeb02c0d77b2febc5a276aad5bbbae600d202eb` to [`uwplasma/NEOPAX@7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc`](https://github.com/uwplasma/NEOPAX/commit/7a05af8be79b7ea5ae8e1d8bf9c833c2c0fb31bc). The package's dependency requirements are unchanged.

**Tested:** `pixi lock --manifest-path stages/pixi.toml --check` and `git diff --check` pass. `pixi run --locked -e test test` passes with 680 tests passed, 7 skipped, and 4 doctests passed. Container builds and solver runs were not performed.
